### PR TITLE
Fix current element not updated when children is updated externally

### DIFF
--- a/src/components/TextLoop.tsx
+++ b/src/components/TextLoop.tsx
@@ -111,8 +111,12 @@ class TextLoop extends React.PureComponent<Props, State> {
 
         if (!isEqual(prevProps.children, children)) {
             // eslint-disable-next-line react/no-did-update-set-state
-            this.setState({
-                elements: React.Children.toArray(children),
+            this.setState((state, props) => {
+                const newElements = React.Children.toArray(children);
+                return {
+                    elements: newElements,
+                    currentEl: newElements[state.currentWordIndex],
+                };
             });
         }
     }


### PR DESCRIPTION
As the current element is a copy of array from children, external changes were not reflected immediately.

The fix will update current element immediately when children is updated.